### PR TITLE
Production-ize: add tests, linting, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    name: Lint & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install ruff pytest pytest-asyncio
+
+      - name: Check Python syntax
+        run: python -m compileall custom_components/norman_shutters -q
+
+      - name: Lint with ruff
+        run: |
+          ruff check custom_components/ tests/
+          ruff format --check custom_components/ tests/
+
+      - name: Run tests
+        run: pytest tests/ -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.ruff_cache/
+.venv/
+dist/
+*.egg-info/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# Norman Shutters HA Integration
+
+## After every change
+
+Always run the following before finishing:
+
+```bash
+ruff check custom_components/ tests/
+ruff format --check custom_components/ tests/
+pytest tests/ -v
+```
+
+Fix any lint errors or test failures before considering the task complete.

--- a/custom_components/norman_shutters/config_flow.py
+++ b/custom_components/norman_shutters/config_flow.py
@@ -7,8 +7,8 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.data_entry_flow import FlowResult
-
 from pynormanshutters.main import login
+
 from .const import CONF_HOST, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -29,9 +29,7 @@ class NormanShuttersConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     # Manual setup (user-initiated from Integrations UI)
     # ------------------------------------------------------------------
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         errors: dict[str, str] = {}
 
         if user_input is not None:
@@ -59,9 +57,7 @@ class NormanShuttersConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     # Zeroconf auto-discovery
     # ------------------------------------------------------------------
 
-    async def async_step_zeroconf(
-        self, discovery_info: ZeroconfServiceInfo
-    ) -> FlowResult:
+    async def async_step_zeroconf(self, discovery_info: ZeroconfServiceInfo) -> FlowResult:
         """Handle discovery of a Norman Hub via mDNS."""
         self._host = discovery_info.host
 

--- a/custom_components/norman_shutters/coordinator.py
+++ b/custom_components/norman_shutters/coordinator.py
@@ -3,8 +3,8 @@ from datetime import timedelta
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-
 from pynormanshutters import login
+
 from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/norman_shutters/cover.py
+++ b/custom_components/norman_shutters/cover.py
@@ -11,8 +11,8 @@ from homeassistant.components.cover import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-
 from pynormanshutters import FULLY_OPEN_POSITION
+
 from .const import DOMAIN
 from .coordinator import NormanCoordinator
 from .entity import NormanEntity
@@ -26,9 +26,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator: NormanCoordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities(
-        NormanCover(coordinator, window_id) for window_id in coordinator.data
-    )
+    async_add_entities(NormanCover(coordinator, window_id) for window_id in coordinator.data)
 
 
 class NormanCover(NormanEntity, CoverEntity):
@@ -41,9 +39,7 @@ class NormanCover(NormanEntity, CoverEntity):
 
     _attr_device_class = CoverDeviceClass.SHUTTER
     _attr_supported_features = (
-        CoverEntityFeature.OPEN
-        | CoverEntityFeature.CLOSE
-        | CoverEntityFeature.SET_TILT_POSITION
+        CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE | CoverEntityFeature.SET_TILT_POSITION
     )
 
     def __init__(self, coordinator: NormanCoordinator, window_id: str) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "ha-norman-shutters"
+version = "1.0.0"
+requires-python = ">=3.12"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+pythonpath = ["."]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "C4"]
+ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["S101"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "ruff>=0.4",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,182 @@
+"""
+Stub all Home Assistant and pynormanshutters imports at module scope so that
+integration modules can be imported without installing homeassistant or
+pynormanshutters.  This file is loaded by pytest before any test module, so
+the sys.modules patch is in place when test files import from
+custom_components.
+"""
+
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub base classes — must be real Python classes, not MagicMock, because
+# the integration classes inherit from them.
+# ---------------------------------------------------------------------------
+
+
+class FakeDataUpdateCoordinator:
+    def __init__(self, hass, logger, *, name, update_interval):
+        self.hass = hass
+        self.data = {}
+
+
+class FakeCoordinatorEntity:
+    def __init__(self, coordinator):
+        self.coordinator = coordinator
+        self.hass = coordinator.hass
+
+    def __class_getitem__(cls, item):
+        # Support CoordinatorEntity[NormanCoordinator] generic syntax in entity.py
+        return cls
+
+
+class FakeConfigFlow:
+    """Minimal ConfigFlow stub that handles the 'domain=' class keyword."""
+
+    VERSION = 1
+
+    def __init_subclass__(cls, domain=None, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+    async def async_set_unique_id(self, uid):
+        pass
+
+    def _abort_if_unique_id_configured(self, updates=None):
+        pass
+
+    def async_show_form(
+        self,
+        *,
+        step_id,
+        data_schema=None,
+        errors=None,
+        description_placeholders=None,
+    ):
+        return {"type": "form", "step_id": step_id, "errors": errors or {}}
+
+    def async_create_entry(self, *, title, data):
+        return {"type": "create_entry", "title": title, "data": data}
+
+
+# CoverEntityFeature constants must be integers for bitwise OR at class
+# definition time (NormanCover sets _attr_supported_features = OPEN | CLOSE | ...).
+_CoverEntityFeature = SimpleNamespace(OPEN=1, CLOSE=2, SET_TILT_POSITION=4)
+_CoverDeviceClass = SimpleNamespace(SHUTTER="shutter")
+_SensorDeviceClass = SimpleNamespace(BATTERY="battery")
+_SensorStateClass = SimpleNamespace(MEASUREMENT="measurement")
+
+
+# ---------------------------------------------------------------------------
+# Build and inject fake HA module tree
+# ---------------------------------------------------------------------------
+
+
+def _mod(name, **attrs):
+    m = ModuleType(name)
+    for k, v in attrs.items():
+        setattr(m, k, v)
+    return m
+
+
+_login_mock = MagicMock()
+
+sys.modules.update(
+    {
+        "homeassistant": _mod("homeassistant"),
+        "homeassistant.core": _mod("homeassistant.core", HomeAssistant=MagicMock),
+        "homeassistant.config_entries": _mod(
+            "homeassistant.config_entries",
+            ConfigEntry=MagicMock,
+            ConfigFlow=FakeConfigFlow,
+        ),
+        "homeassistant.data_entry_flow": _mod(
+            "homeassistant.data_entry_flow",
+            FlowResult=dict,
+        ),
+        "homeassistant.components": _mod("homeassistant.components"),
+        "homeassistant.components.cover": _mod(
+            "homeassistant.components.cover",
+            CoverEntity=object,
+            CoverEntityFeature=_CoverEntityFeature,
+            CoverDeviceClass=_CoverDeviceClass,
+        ),
+        "homeassistant.components.sensor": _mod(
+            "homeassistant.components.sensor",
+            SensorEntity=object,
+            SensorDeviceClass=_SensorDeviceClass,
+            SensorStateClass=_SensorStateClass,
+        ),
+        "homeassistant.components.zeroconf": _mod(
+            "homeassistant.components.zeroconf",
+            ZeroconfServiceInfo=MagicMock,
+        ),
+        "homeassistant.const": _mod("homeassistant.const", PERCENTAGE="%"),
+        "homeassistant.helpers": _mod("homeassistant.helpers"),
+        "homeassistant.helpers.update_coordinator": _mod(
+            "homeassistant.helpers.update_coordinator",
+            DataUpdateCoordinator=FakeDataUpdateCoordinator,
+            CoordinatorEntity=FakeCoordinatorEntity,
+            UpdateFailed=Exception,
+        ),
+        "homeassistant.helpers.device_registry": _mod(
+            "homeassistant.helpers.device_registry",
+            DeviceInfo=dict,
+        ),
+        "homeassistant.helpers.entity_platform": _mod(
+            "homeassistant.helpers.entity_platform",
+            AddEntitiesCallback=None,
+        ),
+        "homeassistant.exceptions": _mod(
+            "homeassistant.exceptions",
+            ConfigEntryNotReady=Exception,
+        ),
+        "pynormanshutters": _mod(
+            "pynormanshutters",
+            login=_login_mock,
+            FULLY_OPEN_POSITION=100,
+        ),
+        "pynormanshutters.main": _mod("pynormanshutters.main", login=_login_mock),
+        "voluptuous": _mod("voluptuous", Schema=MagicMock(), Required=MagicMock()),
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_hass():
+    """Minimal hass-like object with a synchronous async_add_executor_job."""
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *args: fn(*args))
+    return hass
+
+
+@pytest.fixture
+def fake_coordinator(fake_hass):
+    """NormanCoordinator wired to fake_hass with a mock client."""
+    from custom_components.norman_shutters.coordinator import NormanCoordinator
+
+    coordinator = NormanCoordinator(fake_hass, "192.168.1.100")
+    coordinator.client = MagicMock()
+    coordinator.async_request_refresh = AsyncMock()
+    return coordinator
+
+
+@pytest.fixture
+def config_flow(fake_hass):
+    """NormanShuttersConfigFlow with hass and context pre-set."""
+    from custom_components.norman_shutters.config_flow import NormanShuttersConfigFlow
+
+    flow = NormanShuttersConfigFlow()
+    flow.hass = fake_hass
+    # NormanShuttersConfigFlow.__init__ doesn't call super().__init__(), so
+    # self.context is not set automatically — set it here for zeroconf tests.
+    flow.context = {}
+    return flow

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,80 @@
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.norman_shutters.const import CONF_HOST
+
+
+def make_discovery(name, host):
+    info = MagicMock()
+    info.name = name
+    info.host = host
+    return info
+
+
+# ---------------------------------------------------------------------------
+# async_step_zeroconf
+# ---------------------------------------------------------------------------
+
+
+async def test_zeroconf_sets_host_and_unique_id(config_flow):
+    discovery = make_discovery("NORMANHUB_AABBCC._http._tcp.local.", "192.168.1.10")
+    await config_flow.async_step_zeroconf(discovery)
+
+    assert config_flow._host == "192.168.1.10"
+    assert config_flow._unique_id == "AABBCC"
+
+
+async def test_zeroconf_returns_form(config_flow):
+    discovery = make_discovery("NORMANHUB_AABBCC._http._tcp.local.", "192.168.1.10")
+    result = await config_flow.async_step_zeroconf(discovery)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "zeroconf_confirm"
+
+
+# ---------------------------------------------------------------------------
+# async_step_zeroconf_confirm
+# ---------------------------------------------------------------------------
+
+
+async def test_zeroconf_confirm_no_input_shows_form(config_flow):
+    config_flow._host = "192.168.1.10"
+    result = await config_flow.async_step_zeroconf_confirm(None)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "zeroconf_confirm"
+
+
+async def test_zeroconf_confirm_with_input_creates_entry(config_flow):
+    config_flow._host = "192.168.1.10"
+    result = await config_flow.async_step_zeroconf_confirm({})
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_HOST] == "192.168.1.10"
+
+
+# ---------------------------------------------------------------------------
+# async_step_user
+# ---------------------------------------------------------------------------
+
+
+async def test_user_step_no_input_shows_form(config_flow):
+    result = await config_flow.async_step_user(None)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+
+
+async def test_user_step_connection_failure(config_flow):
+    config_flow.hass.async_add_executor_job.side_effect = Exception("cannot connect")
+    result = await config_flow.async_step_user({CONF_HOST: "192.168.1.100"})
+
+    assert result["type"] == "form"
+    assert result["errors"]["base"] == "cannot_connect"
+
+
+async def test_user_step_success(config_flow):
+    config_flow.hass.async_add_executor_job = AsyncMock(return_value=MagicMock())
+    result = await config_flow.async_step_user({CONF_HOST: "192.168.1.100"})
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_HOST] == "192.168.1.100"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,95 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.norman_shutters.coordinator import NormanCoordinator
+
+SAMPLE_WINDOW = {
+    "Id": 52280,
+    "Name": "Right Window 1",
+    "position": 37,
+    "angle": 0,
+    "battery": "57",
+    "solar": 245,
+    "Rssi": 67,
+    "temp": 17,
+}
+
+
+# ---------------------------------------------------------------------------
+# _parse_window_info
+# ---------------------------------------------------------------------------
+
+
+def test_parse_empty_windows():
+    result = NormanCoordinator._parse_window_info({"totalWindow": 0, "windows": []})
+    assert result == {}
+
+
+def test_parse_missing_windows_key():
+    result = NormanCoordinator._parse_window_info({})
+    assert result == {}
+
+
+def test_parse_id_stringified():
+    result = NormanCoordinator._parse_window_info({"windows": [SAMPLE_WINDOW]})
+    assert "52280" in result
+    assert 52280 not in result
+
+
+def test_parse_preserves_raw_dict():
+    window = dict(SAMPLE_WINDOW)
+    result = NormanCoordinator._parse_window_info({"windows": [window]})
+    assert result["52280"] is window
+
+
+def test_parse_multiple_windows():
+    windows = [
+        {**SAMPLE_WINDOW, "Id": 1, "Name": "Window A"},
+        {**SAMPLE_WINDOW, "Id": 2, "Name": "Window B"},
+    ]
+    result = NormanCoordinator._parse_window_info({"windows": windows})
+    assert set(result.keys()) == {"1", "2"}
+
+
+# ---------------------------------------------------------------------------
+# _async_update_data
+# ---------------------------------------------------------------------------
+
+
+async def test_update_data_success(fake_coordinator):
+    raw = {"windows": [dict(SAMPLE_WINDOW)]}
+    fake_coordinator.client.get_window_info.return_value = raw
+
+    result = await fake_coordinator._async_update_data()
+
+    assert "52280" in result
+    assert result["52280"]["Name"] == "Right Window 1"
+
+
+async def test_update_data_retries_on_failure(fake_coordinator):
+    raw = {"windows": [dict(SAMPLE_WINDOW)]}
+    call_count = 0
+
+    def get_window_info():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise OSError("session expired")
+        return raw
+
+    fake_coordinator.client.get_window_info.side_effect = get_window_info
+    fake_coordinator._async_setup = AsyncMock()
+
+    result = await fake_coordinator._async_update_data()
+
+    fake_coordinator._async_setup.assert_called_once()
+    assert "52280" in result
+
+
+async def test_update_data_raises_update_failed(fake_coordinator):
+    fake_coordinator.client.get_window_info.side_effect = OSError("always fails")
+    fake_coordinator._async_setup = AsyncMock()
+
+    with pytest.raises(Exception, match="Error communicating"):
+        await fake_coordinator._async_update_data()

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -1,0 +1,129 @@
+import pynormanshutters
+
+from custom_components.norman_shutters.cover import NormanCover
+
+FULLY_OPEN_POSITION = pynormanshutters.FULLY_OPEN_POSITION
+
+BASE_WINDOW = {
+    "Id": 42,
+    "Name": "Living Room",
+    "position": 50,
+    "angle": 0,
+    "battery": "75",
+    "solar": 200,
+    "Rssi": 60,
+    "temp": 20,
+}
+
+
+def make_cover(coordinator, window_data):
+    coordinator.data = {"42": window_data}
+    return NormanCover(coordinator, "42")
+
+
+# ---------------------------------------------------------------------------
+# name
+# ---------------------------------------------------------------------------
+
+
+def test_name_from_Name_key(fake_coordinator):
+    cover = make_cover(fake_coordinator, {**BASE_WINDOW, "Name": "Lounge"})
+    assert cover.name == "Lounge"
+
+
+def test_name_falls_back_to_window_id(fake_coordinator):
+    data = {k: v for k, v in BASE_WINDOW.items() if k != "Name"}
+    cover = make_cover(fake_coordinator, data)
+    assert cover.name == "42"
+
+
+# ---------------------------------------------------------------------------
+# is_closed
+# ---------------------------------------------------------------------------
+
+
+def test_is_closed_zero(fake_coordinator):
+    cover = make_cover(fake_coordinator, {**BASE_WINDOW, "position": 0})
+    assert cover.is_closed is True
+
+
+def test_is_closed_nonzero(fake_coordinator):
+    cover = make_cover(fake_coordinator, {**BASE_WINDOW, "position": 50})
+    assert cover.is_closed is False
+
+
+def test_is_closed_string_zero(fake_coordinator):
+    cover = make_cover(fake_coordinator, {**BASE_WINDOW, "position": "0"})
+    assert cover.is_closed is True
+
+
+def test_is_closed_none_when_missing(fake_coordinator):
+    data = {k: v for k, v in BASE_WINDOW.items() if k != "position"}
+    cover = make_cover(fake_coordinator, data)
+    assert cover.is_closed is None
+
+
+# ---------------------------------------------------------------------------
+# current_cover_tilt_position
+# ---------------------------------------------------------------------------
+
+
+def test_tilt_fully_open(fake_coordinator):
+    cover = make_cover(fake_coordinator, {**BASE_WINDOW, "position": FULLY_OPEN_POSITION})
+    assert cover.current_cover_tilt_position == 100
+
+
+def test_tilt_half(fake_coordinator):
+    cover = make_cover(fake_coordinator, {**BASE_WINDOW, "position": FULLY_OPEN_POSITION // 2})
+    assert cover.current_cover_tilt_position == 50
+
+
+def test_tilt_zero(fake_coordinator):
+    cover = make_cover(fake_coordinator, {**BASE_WINDOW, "position": 0})
+    assert cover.current_cover_tilt_position == 0
+
+
+def test_tilt_none_when_missing(fake_coordinator):
+    data = {k: v for k, v in BASE_WINDOW.items() if k != "position"}
+    cover = make_cover(fake_coordinator, data)
+    assert cover.current_cover_tilt_position is None
+
+
+# ---------------------------------------------------------------------------
+# _window_int_id
+# ---------------------------------------------------------------------------
+
+
+def test_window_int_id(fake_coordinator):
+    cover = make_cover(fake_coordinator, BASE_WINDOW)
+    assert cover._window_int_id == 42
+
+
+# ---------------------------------------------------------------------------
+# async actions
+# ---------------------------------------------------------------------------
+
+
+async def test_open_cover(fake_coordinator):
+    cover = make_cover(fake_coordinator, BASE_WINDOW)
+    await cover.async_open_cover()
+    fake_coordinator.client.open_window.assert_called_once_with(42)
+    fake_coordinator.async_request_refresh.assert_called_once()
+
+
+async def test_close_cover(fake_coordinator):
+    cover = make_cover(fake_coordinator, BASE_WINDOW)
+    await cover.async_close_cover()
+    fake_coordinator.client.close_window.assert_called_once_with(42)
+    fake_coordinator.async_request_refresh.assert_called_once()
+
+
+async def test_set_tilt_position_math(fake_coordinator):
+    cover = make_cover(fake_coordinator, BASE_WINDOW)
+    tilt_pct = 50
+    expected_native = round(tilt_pct * FULLY_OPEN_POSITION / 100)
+
+    await cover.async_set_cover_tilt_position(tilt_position=tilt_pct)
+
+    fake_coordinator.client.set_window_position.assert_called_once_with(42, expected_native)
+    fake_coordinator.async_request_refresh.assert_called_once()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,60 @@
+from custom_components.norman_shutters.sensor import NormanBatterySensor
+
+BASE_WINDOW = {
+    "Id": 42,
+    "Name": "Bedroom",
+    "position": 50,
+    "battery": "75",
+}
+
+
+def make_sensor(coordinator, window_data):
+    coordinator.data = {"42": window_data}
+    return NormanBatterySensor(coordinator, "42")
+
+
+# ---------------------------------------------------------------------------
+# name
+# ---------------------------------------------------------------------------
+
+
+def test_name_with_Name_key(fake_coordinator):
+    sensor = make_sensor(fake_coordinator, {**BASE_WINDOW, "Name": "Bedroom"})
+    assert sensor.name == "Bedroom Battery"
+
+
+def test_name_falls_back_to_window_id(fake_coordinator):
+    data = {k: v for k, v in BASE_WINDOW.items() if k != "Name"}
+    sensor = make_sensor(fake_coordinator, data)
+    assert sensor.name == "42 Battery"
+
+
+# ---------------------------------------------------------------------------
+# native_value
+# ---------------------------------------------------------------------------
+
+
+def test_native_value_string(fake_coordinator):
+    sensor = make_sensor(fake_coordinator, {**BASE_WINDOW, "battery": "57"})
+    assert sensor.native_value == 57
+
+
+def test_native_value_int(fake_coordinator):
+    sensor = make_sensor(fake_coordinator, {**BASE_WINDOW, "battery": 80})
+    assert sensor.native_value == 80
+
+
+def test_native_value_none_when_missing(fake_coordinator):
+    data = {k: v for k, v in BASE_WINDOW.items() if k != "battery"}
+    sensor = make_sensor(fake_coordinator, data)
+    assert sensor.native_value is None
+
+
+# ---------------------------------------------------------------------------
+# unique_id
+# ---------------------------------------------------------------------------
+
+
+def test_unique_id(fake_coordinator):
+    sensor = make_sensor(fake_coordinator, BASE_WINDOW)
+    assert sensor._attr_unique_id == "42_battery"


### PR DESCRIPTION
## Summary

- **35 unit tests** across coordinator, cover, sensor, and config flow modules — no `homeassistant` package required (all HA imports stubbed via `sys.modules` in `tests/conftest.py`)
- **ruff** configured for linting (E, W, F, I, UP, B, SIM, C4 rules) and formatting
- **GitHub Actions CI** runs on every push/PR to main: Python syntax check → ruff lint+format → pytest
- **CLAUDE.md** instructs future Claude sessions to lint and test after every change
- Minor: fixed import ordering in `coordinator.py`, `cover.py`, `config_flow.py` to satisfy ruff isort

## Test plan

- [x] CI workflow triggers and all three steps (syntax, lint, tests) pass on this PR
- [x] `pip install ruff pytest pytest-asyncio && pytest tests/ -v` passes locally (35 tests)
- [x] `ruff check custom_components/ tests/ && ruff format --check custom_components/ tests/` exits clean