### PR TITLE
Update CLAUDE.md to source .venv before running ruff and pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ __pycache__/
 .venv/
 dist/
 *.egg-info/
+.DS_Store
 ha-config/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,12 +2,12 @@
 
 ## After every change
 
-Always run the following before finishing:
+Always run the following before finishing. Tools like `ruff` and `pytest` are installed in the `.venv` virtualenv — always source it first:
 
 ```bash
-ruff check custom_components/ tests/
-ruff format --check custom_components/ tests/
-pytest tests/ -v
+source .venv/bin/activate && ruff check custom_components/ tests/
+source .venv/bin/activate && ruff format --check custom_components/ tests/
+source .venv/bin/activate && pytest tests/ -v
 ```
 
 Fix any lint errors or test failures before considering the task complete.


### PR DESCRIPTION
## Summary

- Updates `CLAUDE.md` instructions to prefix `ruff` and `pytest` commands with `source .venv/bin/activate &&`
- Ensures tools are found since they are installed in the project virtualenv, not on the system PATH

## Test plan

- [x] Verify the commands in CLAUDE.md work correctly when followed