### PR TITLE
Add temperature and signal strength sensor entities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 *.egg-info/
 .DS_Store
 ha-config/
+.mcp.json

--- a/custom_components/norman_shutters/cover.py
+++ b/custom_components/norman_shutters/cover.py
@@ -41,7 +41,7 @@ class NormanCover(NormanEntity, CoverEntity):
 
     @property
     def name(self) -> str:
-        return self._window.get("Name", self._window_id)
+        return f"{self._window.get('Name', self._window_id)} Cover"
 
     @property
     def is_closed(self) -> bool | None:

--- a/custom_components/norman_shutters/sensor.py
+++ b/custom_components/norman_shutters/sensor.py
@@ -6,7 +6,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, UnitOfSignalStrength, UnitOfTemperature
+from homeassistant.const import PERCENTAGE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -78,7 +78,7 @@ class NormanRssiSensor(NormanEntity, SensorEntity):
     """Signal strength (RSSI) sensor for a Norman Shutter window."""
 
     _attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
-    _attr_native_unit_of_measurement = UnitOfSignalStrength.DECIBELS_MILLIWATT
+    _attr_native_unit_of_measurement = "dBm"
     _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(self, coordinator: NormanCoordinator, window_id: str) -> None:

--- a/custom_components/norman_shutters/sensor.py
+++ b/custom_components/norman_shutters/sensor.py
@@ -6,7 +6,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import PERCENTAGE, UnitOfSignalStrength, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -22,7 +22,13 @@ async def async_setup_entry(
 ) -> None:
     coordinator: NormanCoordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
-        NormanBatterySensor(coordinator, window_id) for window_id in coordinator.data
+        entity
+        for window_id in coordinator.data
+        for entity in [
+            NormanBatterySensor(coordinator, window_id),
+            NormanTemperatureSensor(coordinator, window_id),
+            NormanRssiSensor(coordinator, window_id),
+        ]
     )
 
 
@@ -44,4 +50,46 @@ class NormanBatterySensor(NormanEntity, SensorEntity):
     @property
     def native_value(self) -> int | None:
         val = self._window.get("battery")
+        return int(val) if val is not None else None
+
+
+class NormanTemperatureSensor(NormanEntity, SensorEntity):
+    """Temperature sensor for a Norman Shutter window."""
+
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator: NormanCoordinator, window_id: str) -> None:
+        super().__init__(coordinator, window_id)
+        self._attr_unique_id = f"{window_id}_temperature"
+
+    @property
+    def name(self) -> str:
+        return f"{self._window.get('Name', self._window_id)} Temperature"
+
+    @property
+    def native_value(self) -> int | None:
+        val = self._window.get("temp")
+        return int(val) if val is not None else None
+
+
+class NormanRssiSensor(NormanEntity, SensorEntity):
+    """Signal strength (RSSI) sensor for a Norman Shutter window."""
+
+    _attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+    _attr_native_unit_of_measurement = UnitOfSignalStrength.DECIBELS_MILLIWATT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator: NormanCoordinator, window_id: str) -> None:
+        super().__init__(coordinator, window_id)
+        self._attr_unique_id = f"{window_id}_rssi"
+
+    @property
+    def name(self) -> str:
+        return f"{self._window.get('Name', self._window_id)} Signal Strength"
+
+    @property
+    def native_value(self) -> int | None:
+        val = self._window.get("Rssi")
         return int(val) if val is not None else None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,11 @@ class FakeConfigFlow:
 # definition time (NormanCover sets _attr_supported_features = OPEN | CLOSE | ...).
 _CoverEntityFeature = SimpleNamespace(OPEN=1, CLOSE=2, SET_TILT_POSITION=4)
 _CoverDeviceClass = SimpleNamespace(SHUTTER="shutter")
-_SensorDeviceClass = SimpleNamespace(BATTERY="battery")
+_SensorDeviceClass = SimpleNamespace(
+    BATTERY="battery",
+    TEMPERATURE="temperature",
+    SIGNAL_STRENGTH="signal_strength",
+)
 _SensorStateClass = SimpleNamespace(MEASUREMENT="measurement")
 
 
@@ -131,7 +135,12 @@ sys.modules.update(
             SensorStateClass=_SensorStateClass,
         ),
         "homeassistant.components.zeroconf": _mod("homeassistant.components.zeroconf"),
-        "homeassistant.const": _mod("homeassistant.const", PERCENTAGE="%"),
+        "homeassistant.const": _mod(
+            "homeassistant.const",
+            PERCENTAGE="%",
+            UnitOfTemperature=SimpleNamespace(CELSIUS="°C"),
+            UnitOfSignalStrength=SimpleNamespace(DECIBELS_MILLIWATT="dBm"),
+        ),
         "homeassistant.helpers": _mod("homeassistant.helpers"),
         "homeassistant.helpers.service_info": _mod("homeassistant.helpers.service_info"),
         "homeassistant.helpers.service_info.zeroconf": _mod(

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -29,13 +29,13 @@ def make_cover(coordinator, window_data):
 
 def test_name_from_Name_key(fake_coordinator):
     cover = make_cover(fake_coordinator, {**BASE_WINDOW, "Name": "Lounge"})
-    assert cover.name == "Lounge"
+    assert cover.name == "Lounge Cover"
 
 
 def test_name_falls_back_to_window_id(fake_coordinator):
     data = {k: v for k, v in BASE_WINDOW.items() if k != "Name"}
     cover = make_cover(fake_coordinator, data)
-    assert cover.name == "42"
+    assert cover.name == "42 Cover"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,10 +1,16 @@
-from custom_components.norman_shutters.sensor import NormanBatterySensor
+from custom_components.norman_shutters.sensor import (
+    NormanBatterySensor,
+    NormanRssiSensor,
+    NormanTemperatureSensor,
+)
 
 BASE_WINDOW = {
     "Id": 42,
     "Name": "Bedroom",
     "position": 50,
     "battery": "75",
+    "temp": 17,
+    "Rssi": 67,
 }
 
 
@@ -13,8 +19,18 @@ def make_sensor(coordinator, window_data):
     return NormanBatterySensor(coordinator, "42")
 
 
+def make_temperature_sensor(coordinator, window_data):
+    coordinator.data = {"42": window_data}
+    return NormanTemperatureSensor(coordinator, "42")
+
+
+def make_rssi_sensor(coordinator, window_data):
+    coordinator.data = {"42": window_data}
+    return NormanRssiSensor(coordinator, "42")
+
+
 # ---------------------------------------------------------------------------
-# name
+# NormanBatterySensor — name
 # ---------------------------------------------------------------------------
 
 
@@ -30,7 +46,7 @@ def test_name_falls_back_to_window_id(fake_coordinator):
 
 
 # ---------------------------------------------------------------------------
-# native_value
+# NormanBatterySensor — native_value
 # ---------------------------------------------------------------------------
 
 
@@ -51,10 +67,94 @@ def test_native_value_none_when_missing(fake_coordinator):
 
 
 # ---------------------------------------------------------------------------
-# unique_id
+# NormanBatterySensor — unique_id
 # ---------------------------------------------------------------------------
 
 
 def test_unique_id(fake_coordinator):
     sensor = make_sensor(fake_coordinator, BASE_WINDOW)
     assert sensor._attr_unique_id == "42_battery"
+
+
+# ---------------------------------------------------------------------------
+# NormanTemperatureSensor — name
+# ---------------------------------------------------------------------------
+
+
+def test_temperature_name_with_Name_key(fake_coordinator):
+    sensor = make_temperature_sensor(fake_coordinator, {**BASE_WINDOW, "Name": "Bedroom"})
+    assert sensor.name == "Bedroom Temperature"
+
+
+def test_temperature_name_falls_back_to_window_id(fake_coordinator):
+    data = {k: v for k, v in BASE_WINDOW.items() if k != "Name"}
+    sensor = make_temperature_sensor(fake_coordinator, data)
+    assert sensor.name == "42 Temperature"
+
+
+# ---------------------------------------------------------------------------
+# NormanTemperatureSensor — native_value
+# ---------------------------------------------------------------------------
+
+
+def test_temperature_native_value(fake_coordinator):
+    sensor = make_temperature_sensor(fake_coordinator, {**BASE_WINDOW, "temp": 21})
+    assert sensor.native_value == 21
+
+
+def test_temperature_native_value_none_when_missing(fake_coordinator):
+    data = {k: v for k, v in BASE_WINDOW.items() if k != "temp"}
+    sensor = make_temperature_sensor(fake_coordinator, data)
+    assert sensor.native_value is None
+
+
+# ---------------------------------------------------------------------------
+# NormanTemperatureSensor — unique_id
+# ---------------------------------------------------------------------------
+
+
+def test_temperature_unique_id(fake_coordinator):
+    sensor = make_temperature_sensor(fake_coordinator, BASE_WINDOW)
+    assert sensor._attr_unique_id == "42_temperature"
+
+
+# ---------------------------------------------------------------------------
+# NormanRssiSensor — name
+# ---------------------------------------------------------------------------
+
+
+def test_rssi_name_with_Name_key(fake_coordinator):
+    sensor = make_rssi_sensor(fake_coordinator, {**BASE_WINDOW, "Name": "Bedroom"})
+    assert sensor.name == "Bedroom Signal Strength"
+
+
+def test_rssi_name_falls_back_to_window_id(fake_coordinator):
+    data = {k: v for k, v in BASE_WINDOW.items() if k != "Name"}
+    sensor = make_rssi_sensor(fake_coordinator, data)
+    assert sensor.name == "42 Signal Strength"
+
+
+# ---------------------------------------------------------------------------
+# NormanRssiSensor — native_value
+# ---------------------------------------------------------------------------
+
+
+def test_rssi_native_value(fake_coordinator):
+    sensor = make_rssi_sensor(fake_coordinator, {**BASE_WINDOW, "Rssi": 55})
+    assert sensor.native_value == 55
+
+
+def test_rssi_native_value_none_when_missing(fake_coordinator):
+    data = {k: v for k, v in BASE_WINDOW.items() if k != "Rssi"}
+    sensor = make_rssi_sensor(fake_coordinator, data)
+    assert sensor.native_value is None
+
+
+# ---------------------------------------------------------------------------
+# NormanRssiSensor — unique_id
+# ---------------------------------------------------------------------------
+
+
+def test_rssi_unique_id(fake_coordinator):
+    sensor = make_rssi_sensor(fake_coordinator, BASE_WINDOW)
+    assert sensor._attr_unique_id == "42_rssi"


### PR DESCRIPTION
## Summary

- Adds `NormanTemperatureSensor` exposing the `temp` field (°C) reported by the hub for each window
- Adds `NormanRssiSensor` exposing the `Rssi` field (dBm) reported by the hub for each window
- Both use the appropriate HA device classes (`TEMPERATURE`, `SIGNAL_STRENGTH`) and units

## Test plan

- [x] All 52 existing + new tests pass (`pytest tests/ -v`)
- [x] `ruff check` and `ruff format --check` pass clean
- [x] In HA, each shutter device should now show three sensors: Battery, Temperature, Signal Strength