### PR TITLE
fix: restore zeroconf autodiscovery

### DIFF
--- a/custom_components/norman_shutters/config_flow.py
+++ b/custom_components/norman_shutters/config_flow.py
@@ -86,7 +86,7 @@ class NormanShuttersConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_zeroconf(self, discovery_info: ZeroconfServiceInfo) -> FlowResult:
         """Handle discovery of a Norman Hub via mDNS."""
-        self._host = discovery_info.host
+        self._host = str(discovery_info.ip_address)
 
         # Service name format: "NORMANHUB_AABBCCDDEEFF._http._tcp.local."
         # Extract the MAC to use as a stable unique ID (survives DHCP changes).

--- a/custom_components/norman_shutters/manifest.json
+++ b/custom_components/norman_shutters/manifest.json
@@ -8,6 +8,6 @@
   "codeowners": ["@tomwilkie"],
   "iot_class": "local_polling",
   "version": "1.0.0",
-  "zeroconf": [{"type": "_http._tcp.local.", "name": "NORMANHUB_*"}],
+  "zeroconf": [{"type": "_http._tcp.local.", "name": "normanhub_*"}],
   "homeassistant": "2024.1.0"
 }

--- a/custom_components/norman_shutters/manifest.json
+++ b/custom_components/norman_shutters/manifest.json
@@ -8,5 +8,6 @@
   "codeowners": ["@tomwilkie"],
   "iot_class": "local_polling",
   "version": "1.0.0",
-  "zeroconf": [{"type": "_http._tcp.local.", "name": "NORMANHUB_*"}]
+  "zeroconf": [{"type": "_http._tcp.local.", "name": "NORMANHUB_*"}],
+  "homeassistant": "2024.1.0"
 }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,3 +1,4 @@
+from ipaddress import IPv4Address
 from unittest.mock import AsyncMock, MagicMock
 
 from custom_components.norman_shutters.const import (
@@ -10,7 +11,7 @@ from custom_components.norman_shutters.const import (
 def make_discovery(name, host):
     info = MagicMock()
     info.name = name
-    info.host = host
+    info.ip_address = IPv4Address(host)
     return info
 
 


### PR DESCRIPTION
Two bugs were preventing the Norman Hub from being autodiscovered:

1. **`ip_address` instead of deprecated `host`** — `ZeroconfServiceInfo.host` was removed in HA 2024.1; switched to `str(discovery_info.ip_address)` and updated tests to match.

2. **Lowercase zeroconf name pattern** — HA lowercases the discovered service name before `fnmatch` comparison (e.g. `normanhub_9ddaa3._http._tcp.local.`), but the manifest had `"NORMANHUB_*"`. On Linux/HAOS, `fnmatch` is case-sensitive so the pattern never matched and `async_step_zeroconf` was never called. Lowercasing the pattern to `"normanhub_*"` fixes discovery.

Fixes #7

Generated with [Claude Code](https://claude.ai/code)