### PR TITLE
fix: recover from silent session expiry causing covers to go unavailable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 .DS_Store
 ha-config/
 .mcp.json
+.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,3 +9,29 @@ make all
 ```
 
 This runs lint, format checks, and tests. The Makefile handles venv setup automatically. Fix any errors or failures before considering the task complete.
+
+## Deploying to Home Assistant
+
+After merging to `main`, install the latest version into the running HA instance via the MCP `update.install` service. You must pass the full (long) git SHA of the commit you want to install:
+
+```
+mcp__home-assistant__ha_call_service(
+    domain="update",
+    service="install",
+    entity_id="update.norman_shutters_update",
+    data={"version": "<full-git-sha>"},
+    wait=False,
+)
+```
+
+The full SHA can be obtained with `git rev-parse HEAD` (or `git rev-parse <branch>`). The entity ID is `update.norman_shutters_update`. HA will need a restart after installation for the new integration code to take effect.
+
+Once installed, restart HA:
+
+```
+mcp__home-assistant__ha_call_service(
+    domain="homeassistant",
+    service="restart",
+    wait=False,
+)
+```

--- a/custom_components/norman_shutters/const.py
+++ b/custom_components/norman_shutters/const.py
@@ -4,3 +4,5 @@ CONF_SCAN_INTERVAL = "scan_interval"
 PLATFORMS = ["cover", "sensor"]
 DEFAULT_SCAN_INTERVAL = 60  # seconds
 AGGRESSIVE_POLL_INITIAL = 2  # seconds — first backoff interval after an operation
+RETRY_DEADLINE = 60  # seconds — give up retrying _async_update_data after this long
+RETRY_INITIAL_DELAY = 1  # seconds — first backoff sleep between update retries

--- a/custom_components/norman_shutters/coordinator.py
+++ b/custom_components/norman_shutters/coordinator.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+import time
 from datetime import timedelta
 
 from homeassistant.core import HomeAssistant, callback
@@ -6,7 +8,13 @@ from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from pynormanshutters import login
 
-from .const import AGGRESSIVE_POLL_INITIAL, DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import (
+    AGGRESSIVE_POLL_INITIAL,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    RETRY_DEADLINE,
+    RETRY_INITIAL_DELAY,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,18 +69,51 @@ class NormanCoordinator(DataUpdateCoordinator):
         self.client = await self.hass.async_add_executor_job(login, self.host)
 
     async def _async_update_data(self) -> dict[str, dict]:
-        """Fetch window state from the hub, re-logging in on session expiry."""
-        try:
-            raw = await self.hass.async_add_executor_job(self.client.get_window_info)
-        except Exception as err:
-            _LOGGER.debug("get_window_info failed (%s), attempting re-login", err)
+        """Fetch window state, retrying with exponential backoff for up to RETRY_DEADLINE seconds.
+
+        Both exceptions and empty-list responses are treated as transient failures.
+        A re-login is attempted before each retry in case the session expired.
+        Raises UpdateFailed only after cumulative sleep reaches RETRY_DEADLINE.
+        """
+        delay = float(RETRY_INITIAL_DELAY)
+        elapsed = 0.0
+        last_err = "unknown error"
+
+        while True:
+            t0 = time.monotonic()
+            try:
+                raw = await self.hass.async_add_executor_job(self.client.get_window_info)
+                call_elapsed = time.monotonic() - t0
+                _LOGGER.debug("get_window_info response in %.3fs: %s", call_elapsed, raw)
+                parsed = self._parse_window_info(raw)
+                _LOGGER.debug("parsed %d window(s): %s", len(parsed), list(parsed.keys()))
+                if parsed:
+                    return parsed
+                _LOGGER.debug("Hub returned empty window list (%.0fs elapsed)", elapsed)
+                last_err = "Hub returned empty window list"
+            except Exception as err:
+                call_elapsed = time.monotonic() - t0
+                _LOGGER.debug(
+                    "get_window_info failed after %.3fs (%.0fs total elapsed): %s",
+                    call_elapsed,
+                    elapsed,
+                    err,
+                )
+                last_err = str(err)
+
+            if elapsed >= RETRY_DEADLINE:
+                raise UpdateFailed(f"Norman Hub unreachable after {int(elapsed)}s: {last_err}")
+
+            # Re-login before next attempt — session may have expired silently
             try:
                 await self._async_setup()
-                raw = await self.hass.async_add_executor_job(self.client.get_window_info)
-            except Exception as err2:
-                raise UpdateFailed(f"Error communicating with Norman Hub: {err2}") from err2
+            except Exception as login_err:
+                _LOGGER.debug("Re-login failed: %s", login_err)
 
-        return self._parse_window_info(raw)
+            sleep_time = min(delay, RETRY_DEADLINE - elapsed)
+            await asyncio.sleep(sleep_time)
+            elapsed += sleep_time
+            delay *= 2
 
     @staticmethod
     def _parse_window_info(raw: dict) -> dict[str, dict]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ class FakeDataUpdateCoordinator:
     def __init__(self, hass, logger, *, name, update_interval):
         self.hass = hass
         self.data = {}
+        self.last_update_success = True
 
 
 class FakeCoordinatorEntity:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.norman_shutters.const import RETRY_DEADLINE
 from custom_components.norman_shutters.coordinator import NormanCoordinator
 
 SAMPLE_WINDOW = {
@@ -58,17 +59,23 @@ def test_parse_multiple_windows():
 
 
 async def test_update_data_success(fake_coordinator):
+    """First attempt succeeds — no sleep, no re-login."""
     raw = {"windows": [dict(SAMPLE_WINDOW)]}
     fake_coordinator.client.get_window_info.return_value = raw
+    fake_coordinator._async_setup = AsyncMock()
 
-    result = await fake_coordinator._async_update_data()
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        result = await fake_coordinator._async_update_data()
 
     assert "52280" in result
     assert result["52280"]["Name"] == "Right Window 1"
+    mock_sleep.assert_not_called()
+    fake_coordinator._async_setup.assert_not_called()
 
 
-async def test_update_data_retries_on_failure(fake_coordinator):
-    raw = {"windows": [dict(SAMPLE_WINDOW)]}
+async def test_update_data_retries_on_exception(fake_coordinator):
+    """An exception on the first call triggers re-login + sleep, then success on retry."""
+    raw_valid = {"windows": [dict(SAMPLE_WINDOW)]}
     call_count = 0
 
     def get_window_info():
@@ -76,23 +83,82 @@ async def test_update_data_retries_on_failure(fake_coordinator):
         call_count += 1
         if call_count == 1:
             raise OSError("session expired")
-        return raw
+        return raw_valid
 
     fake_coordinator.client.get_window_info.side_effect = get_window_info
     fake_coordinator._async_setup = AsyncMock()
 
-    result = await fake_coordinator._async_update_data()
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        result = await fake_coordinator._async_update_data()
 
-    fake_coordinator._async_setup.assert_called_once()
     assert "52280" in result
+    fake_coordinator._async_setup.assert_called_once()
+    mock_sleep.assert_called_once_with(1.0)
 
 
-async def test_update_data_raises_update_failed(fake_coordinator):
+async def test_update_data_retries_on_empty_list(fake_coordinator):
+    """An empty-list response triggers re-login + sleep, then success on retry."""
+    raw_empty = {"totalWindow": 0, "windows": []}
+    raw_valid = {"windows": [dict(SAMPLE_WINDOW)]}
+    call_count = 0
+
+    def get_window_info():
+        nonlocal call_count
+        call_count += 1
+        return raw_empty if call_count == 1 else raw_valid
+
+    fake_coordinator.client.get_window_info.side_effect = get_window_info
+    fake_coordinator._async_setup = AsyncMock()
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        result = await fake_coordinator._async_update_data()
+
+    assert "52280" in result
+    fake_coordinator._async_setup.assert_called_once()
+    mock_sleep.assert_called_once_with(1.0)
+
+
+async def test_update_data_raises_after_deadline(fake_coordinator):
+    """UpdateFailed is raised once cumulative sleep reaches RETRY_DEADLINE."""
     fake_coordinator.client.get_window_info.side_effect = OSError("always fails")
     fake_coordinator._async_setup = AsyncMock()
 
-    with pytest.raises(Exception, match="Error communicating"):
+    # Each asyncio.sleep call advances elapsed by its argument; when elapsed
+    # accumulates to RETRY_DEADLINE the next failure raises UpdateFailed.
+    elapsed_tracker = [0.0]
+
+    async def fake_sleep(seconds):
+        elapsed_tracker[0] += seconds
+
+    with (
+        patch("asyncio.sleep", side_effect=fake_sleep),
+        pytest.raises(Exception, match="Norman Hub unreachable after"),
+    ):
         await fake_coordinator._async_update_data()
+
+    assert elapsed_tracker[0] >= RETRY_DEADLINE
+
+
+async def test_update_data_relogins_before_each_retry(fake_coordinator):
+    """_async_setup is called before every retry, not just the first."""
+    raw_valid = {"windows": [dict(SAMPLE_WINDOW)]}
+    call_count = 0
+
+    def get_window_info():
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            raise OSError("not yet")
+        return raw_valid
+
+    fake_coordinator.client.get_window_info.side_effect = get_window_info
+    fake_coordinator._async_setup = AsyncMock()
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        result = await fake_coordinator._async_update_data()
+
+    assert "52280" in result
+    assert fake_coordinator._async_setup.call_count == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The Norman hub returns HTTP 200 with an empty \`windows\` list when the session cookie expires silently, rather than raising an error. The previous code handled this with a single re-login + retry, giving up immediately if that one attempt also failed — causing all covers to show as unavailable.

\`_async_update_data\` now retries with exponential backoff for up to 60 s. Both exceptions and empty-list responses are treated as transient failures. A re-login is attempted before each retry. \`UpdateFailed\` is only raised once the deadline is exhausted, giving the hub time to recover.

Retry schedule (all attempts fail): 1 s → 2 s → 4 s → 8 s → 16 s → 29 s → raise (60 s total).

Per-call timing and parsed window count are also logged at DEBUG level to aid future diagnosis.

## Changes

- \`const.py\`: add \`RETRY_DEADLINE = 60\` and \`RETRY_INITIAL_DELAY = 1\`
- \`coordinator.py\`: replace \`_async_update_data\` with a unified exponential backoff retry loop; add \`import time\` for per-call timing logs
- \`tests/test_coordinator.py\`: replace old tests with 5 new ones covering success, retry-on-exception, retry-on-empty-list, deadline exhaustion, and multiple re-logins

## Test plan

- [x] All 54 tests pass (`make all`)
- [x] Deployed to HA and monitored via Grafana — no errors, exceptions, re-login attempts, or unavailability events over ~22 hours. All 6 shutters consistently returning data on every poll.