### PR TITLE
Add Makefile for dev workflow (#9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,14 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install dependencies
-        run: pip install ruff pytest pytest-asyncio
+      - name: Set up venv
+        run: make setup
 
       - name: Check Python syntax
-        run: python -m compileall custom_components/norman_shutters -q
+        run: .venv/bin/python -m compileall custom_components/norman_shutters -q
 
       - name: Lint with ruff
-        run: |
-          ruff check custom_components/ tests/
-          ruff format --check custom_components/ tests/
+        run: make lint format-check
 
       - name: Run tests
-        run: pytest tests/ -v
+        run: make test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,12 +2,10 @@
 
 ## After every change
 
-Always run the following before finishing. Tools like `ruff` and `pytest` are installed in the `.venv` virtualenv — always source it first:
+Always run the following before finishing:
 
 ```bash
-source .venv/bin/activate && ruff check custom_components/ tests/
-source .venv/bin/activate && ruff format --check custom_components/ tests/
-source .venv/bin/activate && pytest tests/ -v
+make all
 ```
 
-Fix any lint errors or test failures before considering the task complete.
+This runs lint, format checks, and tests. The Makefile handles venv setup automatically. Fix any errors or failures before considering the task complete.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+VENV := .venv
+PYTHON := $(VENV)/bin/python
+PIP := $(VENV)/bin/pip
+
+.PHONY: all setup lint format format-check test clean
+
+all: lint format-check test
+
+$(VENV)/bin/activate:
+	python3 -m venv $(VENV)
+	$(PIP) install --quiet ruff pytest pytest-asyncio
+
+setup: $(VENV)/bin/activate
+
+lint: setup
+	$(VENV)/bin/ruff check custom_components/ tests/
+
+format-check: setup
+	$(VENV)/bin/ruff format --check custom_components/ tests/
+
+format: setup
+	$(VENV)/bin/ruff format custom_components/ tests/
+
+test: setup
+	$(VENV)/bin/pytest tests/ -v
+
+clean:
+	rm -rf $(VENV) .pytest_cache .ruff_cache __pycache__


### PR DESCRIPTION
## Summary

- Adds a `Makefile` with `setup`, `lint`, `format-check`, `format`, `test`, and `all` targets
- Venv creation is automatic (Make file-based sentinel on `.venv/bin/activate`)
- Updates CI to use `make setup`, `make lint format-check`, and `make test`
- Updates `CLAUDE.md` to use `make all` instead of manual `source .venv/...` commands

## Test plan

- [x] `make all` passes locally (52 tests, lint and format clean)
- [x] Re-running `make setup` is a no-op when venv already exists
- [x] Individual targets (`make lint`, `make test`, `make format-check`) work independently
- [x] CI passes on this PR

Closes #9