### PR TITLE
feat: add Norman Hub device with hub-level controls and zombie-coordinator fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 .DS_Store
 ha-config/
 .mcp.json
+.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,3 +9,29 @@ make all
 ```
 
 This runs lint, format checks, and tests. The Makefile handles venv setup automatically. Fix any errors or failures before considering the task complete.
+
+## Deploying to Home Assistant
+
+After merging to `main`, install the latest version into the running HA instance via the MCP `update.install` service. You must pass the full (long) git SHA of the commit you want to install:
+
+```
+mcp__home-assistant__ha_call_service(
+    domain="update",
+    service="install",
+    entity_id="update.norman_shutters_update",
+    data={"version": "<full-git-sha>"},
+    wait=False,
+)
+```
+
+The full SHA can be obtained with `git rev-parse HEAD` (or `git rev-parse <branch>`). The entity ID is `update.norman_shutters_update`. HA will need a restart after installation for the new integration code to take effect.
+
+Once installed, restart HA:
+
+```
+mcp__home-assistant__ha_call_service(
+    domain="homeassistant",
+    service="restart",
+    wait=False,
+)
+```

--- a/custom_components/norman_shutters/__init__.py
+++ b/custom_components/norman_shutters/__init__.py
@@ -4,7 +4,14 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import CONF_HOST, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN, PLATFORMS
+from .const import (
+    CONF_HOST,
+    CONF_MAC,
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    PLATFORMS,
+)
 from .coordinator import NormanCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -18,7 +25,13 @@ async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Norman Shutters from a config entry."""
     scan_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-    coordinator = NormanCoordinator(hass, entry.data[CONF_HOST], scan_interval)
+    coordinator = NormanCoordinator(
+        hass,
+        entry.data[CONF_HOST],
+        scan_interval,
+        mac_address=entry.data.get(CONF_MAC),
+        config_entry=entry,
+    )
 
     try:
         await coordinator._async_setup()

--- a/custom_components/norman_shutters/config_flow.py
+++ b/custom_components/norman_shutters/config_flow.py
@@ -9,10 +9,13 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from pynormanshutters import login
 
-from .const import CONF_HOST, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import CONF_HOST, CONF_MAC, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+# Norman Hub devices share a common OUI. The mDNS hostname suffix (e.g.
+# "9DDAA3" in "NORMANHUB_9DDAA3") is the last 3 bytes of the MAC address.
+NORMAN_OUI = "805E4F"
 SERVICE_NAME_PREFIX = "NORMANHUB_"
 
 
@@ -51,6 +54,7 @@ class NormanShuttersConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         self._host: str | None = None
         self._unique_id: str | None = None
+        self._mac: str | None = None
 
     # ------------------------------------------------------------------
     # Manual setup (user-initiated from Integrations UI)
@@ -88,11 +92,24 @@ class NormanShuttersConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle discovery of a Norman Hub via mDNS."""
         self._host = str(discovery_info.ip_address)
 
-        # Service name format: "NORMANHUB_AABBCCDDEEFF._http._tcp.local."
-        # Extract the MAC to use as a stable unique ID (survives DHCP changes).
-        raw_name = discovery_info.name  # e.g. "NORMANHUB_AABBCC._http._tcp.local."
-        hub_label = raw_name.split(".")[0]  # "NORMANHUB_AABBCC"
-        self._unique_id = hub_label.removeprefix(SERVICE_NAME_PREFIX) or self._host
+        _LOGGER.debug(
+            "Norman Hub zeroconf discovery: name=%r hostname=%r",
+            discovery_info.name,
+            discovery_info.hostname,
+        )
+
+        # Reconstruct the full MAC from the service name suffix. Norman Hub devices
+        # use a fixed OUI and embed the last 3 MAC bytes in the service name
+        # (e.g. "NORMANHUB_9DDAA3" → full MAC "805E4F9DDAA3").
+        mac_hex: str | None = None
+        hub_label = discovery_info.name.split(".")[0]
+        suffix = hub_label.removeprefix(SERVICE_NAME_PREFIX).upper()
+        hex_chars = set("0123456789ABCDEF")
+        if hub_label != suffix and len(suffix) == 6 and all(c in hex_chars for c in suffix):
+            mac_hex = NORMAN_OUI + suffix
+
+        self._mac = mac_hex
+        self._unique_id = mac_hex or self._host
 
         await self.async_set_unique_id(self._unique_id)
         self._abort_if_unique_id_configured(updates={CONF_HOST: self._host})
@@ -105,9 +122,12 @@ class NormanShuttersConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Confirm addition of a discovered hub."""
         if user_input is not None:
+            data: dict = {CONF_HOST: self._host}
+            if self._mac:
+                data[CONF_MAC] = self._mac
             return self.async_create_entry(
                 title=f"Norman Hub ({self._host})",
-                data={CONF_HOST: self._host},
+                data=data,
             )
 
         return self.async_show_form(

--- a/custom_components/norman_shutters/const.py
+++ b/custom_components/norman_shutters/const.py
@@ -1,6 +1,9 @@
 DOMAIN = "norman_shutters"
 CONF_HOST = "host"
+CONF_MAC = "mac_address"
 CONF_SCAN_INTERVAL = "scan_interval"
 PLATFORMS = ["cover", "sensor"]
 DEFAULT_SCAN_INTERVAL = 60  # seconds
 AGGRESSIVE_POLL_INITIAL = 2  # seconds — first backoff interval after an operation
+RETRY_DEADLINE = 60  # seconds — give up retrying _async_update_data after this long
+RETRY_INITIAL_DELAY = 1  # seconds — first backoff sleep between update retries

--- a/custom_components/norman_shutters/coordinator.py
+++ b/custom_components/norman_shutters/coordinator.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+import time
 from datetime import timedelta
 
 from homeassistant.core import HomeAssistant, callback
@@ -6,7 +8,13 @@ from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from pynormanshutters import login
 
-from .const import AGGRESSIVE_POLL_INITIAL, DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import (
+    AGGRESSIVE_POLL_INITIAL,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    RETRY_DEADLINE,
+    RETRY_INITIAL_DELAY,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -15,15 +23,22 @@ class NormanCoordinator(DataUpdateCoordinator):
     """Coordinator for Norman Shutters - polls get_window_info at a configurable interval."""
 
     def __init__(
-        self, hass: HomeAssistant, host: str, scan_interval: int = DEFAULT_SCAN_INTERVAL
+        self,
+        hass: HomeAssistant,
+        host: str,
+        scan_interval: int = DEFAULT_SCAN_INTERVAL,
+        mac_address: str | None = None,
+        config_entry=None,
     ) -> None:
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
             update_interval=timedelta(seconds=scan_interval),
+            config_entry=config_entry,
         )
         self.host = host
+        self.mac_address = mac_address
         self.client = None
         self._scan_interval = scan_interval
         self._aggressive_poll_unsubs: list = []
@@ -61,18 +76,51 @@ class NormanCoordinator(DataUpdateCoordinator):
         self.client = await self.hass.async_add_executor_job(login, self.host)
 
     async def _async_update_data(self) -> dict[str, dict]:
-        """Fetch window state from the hub, re-logging in on session expiry."""
-        try:
-            raw = await self.hass.async_add_executor_job(self.client.get_window_info)
-        except Exception as err:
-            _LOGGER.debug("get_window_info failed (%s), attempting re-login", err)
+        """Fetch window state, retrying with exponential backoff for up to RETRY_DEADLINE seconds.
+
+        Both exceptions and empty-list responses are treated as transient failures.
+        A re-login is attempted before each retry in case the session expired.
+        Raises UpdateFailed only after cumulative sleep reaches RETRY_DEADLINE.
+        """
+        delay = float(RETRY_INITIAL_DELAY)
+        elapsed = 0.0
+        last_err = "unknown error"
+
+        while True:
+            t0 = time.monotonic()
+            try:
+                raw = await self.hass.async_add_executor_job(self.client.get_window_info)
+                call_elapsed = time.monotonic() - t0
+                _LOGGER.debug("get_window_info response in %.3fs: %s", call_elapsed, raw)
+                parsed = self._parse_window_info(raw)
+                _LOGGER.debug("parsed %d window(s): %s", len(parsed), list(parsed.keys()))
+                if parsed:
+                    return parsed
+                _LOGGER.debug("Hub returned empty window list (%.0fs elapsed)", elapsed)
+                last_err = "Hub returned empty window list"
+            except Exception as err:
+                call_elapsed = time.monotonic() - t0
+                _LOGGER.debug(
+                    "get_window_info failed after %.3fs (%.0fs total elapsed): %s",
+                    call_elapsed,
+                    elapsed,
+                    err,
+                )
+                last_err = str(err)
+
+            if elapsed >= RETRY_DEADLINE:
+                raise UpdateFailed(f"Norman Hub unreachable after {int(elapsed)}s: {last_err}")
+
+            # Re-login before next attempt — session may have expired silently
             try:
                 await self._async_setup()
-                raw = await self.hass.async_add_executor_job(self.client.get_window_info)
-            except Exception as err2:
-                raise UpdateFailed(f"Error communicating with Norman Hub: {err2}") from err2
+            except Exception as login_err:
+                _LOGGER.debug("Re-login failed: %s", login_err)
 
-        return self._parse_window_info(raw)
+            sleep_time = min(delay, RETRY_DEADLINE - elapsed)
+            await asyncio.sleep(sleep_time)
+            elapsed += sleep_time
+            delay *= 2
 
     @staticmethod
     def _parse_window_info(raw: dict) -> dict[str, dict]:

--- a/custom_components/norman_shutters/cover.py
+++ b/custom_components/norman_shutters/cover.py
@@ -15,7 +15,7 @@ from pynormanshutters import FULLY_CLOSED_POSITION
 
 from .const import DOMAIN
 from .coordinator import NormanCoordinator
-from .entity import NormanEntity
+from .entity import NormanEntity, NormanHubEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,7 +26,9 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator: NormanCoordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities(NormanCover(coordinator, window_id) for window_id in coordinator.data)
+    entities: list = [NormanHubCover(coordinator)]
+    entities.extend(NormanCover(coordinator, window_id) for window_id in coordinator.data)
+    async_add_entities(entities)
 
 
 class NormanCover(NormanEntity, CoverEntity):
@@ -66,4 +68,38 @@ class NormanCover(NormanEntity, CoverEntity):
         await self.hass.async_add_executor_job(
             self.coordinator.client.close_window, self._window_int_id
         )
+        await self.coordinator.async_request_aggressive_refresh()
+
+
+class NormanHubCover(NormanHubEntity, CoverEntity):
+    """Cover entity that opens or closes all Norman shutters on the hub at once."""
+
+    _attr_device_class = CoverDeviceClass.SHUTTER
+    _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+
+    def __init__(self, coordinator: NormanCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_name = "All Shutters"
+
+    @property
+    def unique_id(self) -> str:
+        return f"hub_{self._hub_id}_cover"
+
+    @property
+    def is_closed(self) -> bool | None:
+        if not self.coordinator.data:
+            return None
+        positions = [w.get("position") for w in self.coordinator.data.values()]
+        if any(p is None for p in positions):
+            return None
+        return all(int(p) >= FULLY_CLOSED_POSITION for p in positions)
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        _LOGGER.debug("open_cover called for all windows")
+        await self.hass.async_add_executor_job(self.coordinator.client.full_open)
+        await self.coordinator.async_request_aggressive_refresh()
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        _LOGGER.debug("close_cover called for all windows")
+        await self.hass.async_add_executor_job(self.coordinator.client.full_close)
         await self.coordinator.async_request_aggressive_refresh()

--- a/custom_components/norman_shutters/entity.py
+++ b/custom_components/norman_shutters/entity.py
@@ -1,12 +1,18 @@
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import NormanCoordinator
 
 
+def _format_mac(mac_hex: str) -> str:
+    """Normalise a hex-only MAC string (AABBCCDDEEFF) to aa:bb:cc:dd:ee:ff."""
+    mac = mac_hex.lower()
+    return ":".join(mac[i : i + 2] for i in range(0, len(mac), 2))
+
+
 class NormanEntity(CoordinatorEntity[NormanCoordinator]):
-    """Base entity for all Norman Shutters devices."""
+    """Base entity for all Norman Shutters window devices."""
 
     _attr_has_entity_name = True
 
@@ -24,9 +30,37 @@ class NormanEntity(CoordinatorEntity[NormanCoordinator]):
 
     @property
     def device_info(self) -> DeviceInfo:
+        hub_id = self.coordinator.mac_address or self.coordinator.host
         return DeviceInfo(
             identifiers={(DOMAIN, self._window_id)},
             name=self._window.get("Name", self._window_id),
             manufacturer="Norman",
             model="PerfectTilt",
+            via_device=(DOMAIN, f"hub_{hub_id}"),
+        )
+
+
+class NormanHubEntity(CoordinatorEntity[NormanCoordinator]):
+    """Base entity for Norman Hub-level devices."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: NormanCoordinator) -> None:
+        super().__init__(coordinator)
+
+    @property
+    def _hub_id(self) -> str:
+        return self.coordinator.mac_address or self.coordinator.host
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        connections: set[tuple[str, str]] = set()
+        if self.coordinator.mac_address:
+            connections.add((CONNECTION_NETWORK_MAC, _format_mac(self.coordinator.mac_address)))
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"hub_{self._hub_id}")},
+            name="Norman Hub",
+            manufacturer="Norman",
+            model="Norman Hub",
+            connections=connections,
         )

--- a/custom_components/norman_shutters/sensor.py
+++ b/custom_components/norman_shutters/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import NormanCoordinator
-from .entity import NormanEntity
+from .entity import NormanEntity, NormanHubEntity
 
 
 async def async_setup_entry(
@@ -21,7 +21,8 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator: NormanCoordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities(
+    entities: list = [NormanConnectedWindowsSensor(coordinator)]
+    entities.extend(
         entity
         for window_id in coordinator.data
         for entity in [
@@ -30,6 +31,25 @@ async def async_setup_entry(
             NormanRssiSensor(coordinator, window_id),
         ]
     )
+    async_add_entities(entities)
+
+
+class NormanConnectedWindowsSensor(NormanHubEntity, SensorEntity):
+    """Sensor reporting how many shutters are connected to the Norman Hub."""
+
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator: NormanCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_name = "Connected Shutters"
+
+    @property
+    def unique_id(self) -> str:
+        return f"hub_{self._hub_id}_connected_shutters"
+
+    @property
+    def native_value(self) -> int:
+        return len(self.coordinator.data)
 
 
 class NormanBatterySensor(NormanEntity, SensorEntity):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,9 +19,10 @@ import pytest
 
 
 class FakeDataUpdateCoordinator:
-    def __init__(self, hass, logger, *, name, update_interval):
+    def __init__(self, hass, logger, *, name, update_interval, config_entry=None):
         self.hass = hass
         self.data = {}
+        self.last_update_success = True
 
 
 class FakeCoordinatorEntity:
@@ -156,6 +157,7 @@ sys.modules.update(
         "homeassistant.helpers.device_registry": _mod(
             "homeassistant.helpers.device_registry",
             DeviceInfo=dict,
+            CONNECTION_NETWORK_MAC="mac",
         ),
         "homeassistant.helpers.entity_platform": _mod(
             "homeassistant.helpers.entity_platform",
@@ -205,7 +207,9 @@ def fake_coordinator(fake_hass):
     """NormanCoordinator wired to fake_hass with a mock client."""
     from custom_components.norman_shutters.coordinator import NormanCoordinator
 
-    coordinator = NormanCoordinator(fake_hass, "192.168.1.100")
+    coordinator = NormanCoordinator(
+        fake_hass, "192.168.1.100", mac_address="AABBCCDDEEFF", config_entry=MagicMock()
+    )
     coordinator.client = MagicMock()
     coordinator.async_request_refresh = AsyncMock()
     coordinator.async_request_aggressive_refresh = AsyncMock()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from custom_components.norman_shutters.const import (
     CONF_HOST,
+    CONF_MAC,
     CONF_SCAN_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
 )
@@ -11,6 +12,7 @@ from custom_components.norman_shutters.const import (
 def make_discovery(name, host):
     info = MagicMock()
     info.name = name
+    info.hostname = name.split(".")[0] + ".local."
     info.ip_address = IPv4Address(host)
     return info
 
@@ -20,20 +22,37 @@ def make_discovery(name, host):
 # ---------------------------------------------------------------------------
 
 
-async def test_zeroconf_sets_host_and_unique_id(config_flow):
-    discovery = make_discovery("NORMANHUB_AABBCC._http._tcp.local.", "192.168.1.10")
+async def test_zeroconf_sets_host(config_flow):
+    discovery = make_discovery("NORMANHUB_9DDAA3._http._tcp.local.", "192.168.1.10")
     await config_flow.async_step_zeroconf(discovery)
 
     assert config_flow._host == "192.168.1.10"
-    assert config_flow._unique_id == "AABBCC"
 
 
 async def test_zeroconf_returns_form(config_flow):
-    discovery = make_discovery("NORMANHUB_AABBCC._http._tcp.local.", "192.168.1.10")
+    discovery = make_discovery("NORMANHUB_9DDAA3._http._tcp.local.", "192.168.1.10")
     result = await config_flow.async_step_zeroconf(discovery)
 
     assert result["type"] == "form"
     assert result["step_id"] == "zeroconf_confirm"
+
+
+async def test_zeroconf_mac_reconstructed_from_hostname_suffix(config_flow):
+    """Norman OUI + 6-char hostname suffix reconstructs the full MAC."""
+    discovery = make_discovery("NORMANHUB_9DDAA3._http._tcp.local.", "192.168.1.10")
+    await config_flow.async_step_zeroconf(discovery)
+
+    assert config_flow._mac == "805E4F9DDAA3"
+    assert config_flow._unique_id == "805E4F9DDAA3"
+
+
+async def test_zeroconf_no_mac_when_suffix_not_hex(config_flow):
+    """Suffix that isn't valid hex falls back to IP as unique_id."""
+    discovery = make_discovery("NORMANHUB_ZZZZZZ._http._tcp.local.", "192.168.1.10")
+    await config_flow.async_step_zeroconf(discovery)
+
+    assert config_flow._mac is None
+    assert config_flow._unique_id == "192.168.1.10"
 
 
 # ---------------------------------------------------------------------------
@@ -55,6 +74,25 @@ async def test_zeroconf_confirm_with_input_creates_entry(config_flow):
 
     assert result["type"] == "create_entry"
     assert result["data"][CONF_HOST] == "192.168.1.10"
+
+
+async def test_zeroconf_confirm_includes_mac_when_suffix_valid(config_flow):
+    discovery = make_discovery("NORMANHUB_9DDAA3._http._tcp.local.", "192.168.1.10")
+    await config_flow.async_step_zeroconf(discovery)
+    result = await config_flow.async_step_zeroconf_confirm({})
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_MAC] == "805E4F9DDAA3"
+
+
+async def test_zeroconf_confirm_no_mac_when_suffix_not_hex(config_flow):
+    """When neither TXT properties nor a valid hex suffix are available, no MAC is stored."""
+    discovery = make_discovery("NORMANHUB_ZZZZZZ._http._tcp.local.", "192.168.1.10")
+    await config_flow.async_step_zeroconf(discovery)
+    result = await config_flow.async_step_zeroconf_confirm({})
+
+    assert result["type"] == "create_entry"
+    assert CONF_MAC not in result["data"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.norman_shutters.const import RETRY_DEADLINE
 from custom_components.norman_shutters.coordinator import NormanCoordinator
 
 SAMPLE_WINDOW = {
@@ -58,17 +59,23 @@ def test_parse_multiple_windows():
 
 
 async def test_update_data_success(fake_coordinator):
+    """First attempt succeeds — no sleep, no re-login."""
     raw = {"windows": [dict(SAMPLE_WINDOW)]}
     fake_coordinator.client.get_window_info.return_value = raw
+    fake_coordinator._async_setup = AsyncMock()
 
-    result = await fake_coordinator._async_update_data()
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        result = await fake_coordinator._async_update_data()
 
     assert "52280" in result
     assert result["52280"]["Name"] == "Right Window 1"
+    mock_sleep.assert_not_called()
+    fake_coordinator._async_setup.assert_not_called()
 
 
-async def test_update_data_retries_on_failure(fake_coordinator):
-    raw = {"windows": [dict(SAMPLE_WINDOW)]}
+async def test_update_data_retries_on_exception(fake_coordinator):
+    """An exception on the first call triggers re-login + sleep, then success on retry."""
+    raw_valid = {"windows": [dict(SAMPLE_WINDOW)]}
     call_count = 0
 
     def get_window_info():
@@ -76,23 +83,82 @@ async def test_update_data_retries_on_failure(fake_coordinator):
         call_count += 1
         if call_count == 1:
             raise OSError("session expired")
-        return raw
+        return raw_valid
 
     fake_coordinator.client.get_window_info.side_effect = get_window_info
     fake_coordinator._async_setup = AsyncMock()
 
-    result = await fake_coordinator._async_update_data()
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        result = await fake_coordinator._async_update_data()
 
-    fake_coordinator._async_setup.assert_called_once()
     assert "52280" in result
+    fake_coordinator._async_setup.assert_called_once()
+    mock_sleep.assert_called_once_with(1.0)
 
 
-async def test_update_data_raises_update_failed(fake_coordinator):
+async def test_update_data_retries_on_empty_list(fake_coordinator):
+    """An empty-list response triggers re-login + sleep, then success on retry."""
+    raw_empty = {"totalWindow": 0, "windows": []}
+    raw_valid = {"windows": [dict(SAMPLE_WINDOW)]}
+    call_count = 0
+
+    def get_window_info():
+        nonlocal call_count
+        call_count += 1
+        return raw_empty if call_count == 1 else raw_valid
+
+    fake_coordinator.client.get_window_info.side_effect = get_window_info
+    fake_coordinator._async_setup = AsyncMock()
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        result = await fake_coordinator._async_update_data()
+
+    assert "52280" in result
+    fake_coordinator._async_setup.assert_called_once()
+    mock_sleep.assert_called_once_with(1.0)
+
+
+async def test_update_data_raises_after_deadline(fake_coordinator):
+    """UpdateFailed is raised once cumulative sleep reaches RETRY_DEADLINE."""
     fake_coordinator.client.get_window_info.side_effect = OSError("always fails")
     fake_coordinator._async_setup = AsyncMock()
 
-    with pytest.raises(Exception, match="Error communicating"):
+    # Each asyncio.sleep call advances elapsed by its argument; when elapsed
+    # accumulates to RETRY_DEADLINE the next failure raises UpdateFailed.
+    elapsed_tracker = [0.0]
+
+    async def fake_sleep(seconds):
+        elapsed_tracker[0] += seconds
+
+    with (
+        patch("asyncio.sleep", side_effect=fake_sleep),
+        pytest.raises(Exception, match="Norman Hub unreachable after"),
+    ):
         await fake_coordinator._async_update_data()
+
+    assert elapsed_tracker[0] >= RETRY_DEADLINE
+
+
+async def test_update_data_relogins_before_each_retry(fake_coordinator):
+    """_async_setup is called before every retry, not just the first."""
+    raw_valid = {"windows": [dict(SAMPLE_WINDOW)]}
+    call_count = 0
+
+    def get_window_info():
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            raise OSError("not yet")
+        return raw_valid
+
+    fake_coordinator.client.get_window_info.side_effect = get_window_info
+    fake_coordinator._async_setup = AsyncMock()
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        result = await fake_coordinator._async_update_data()
+
+    assert "52280" in result
+    assert fake_coordinator._async_setup.call_count == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -1,6 +1,6 @@
 import pynormanshutters
 
-from custom_components.norman_shutters.cover import NormanCover
+from custom_components.norman_shutters.cover import NormanCover, NormanHubCover
 
 FULLY_OPEN_POSITION = pynormanshutters.FULLY_OPEN_POSITION  # 37 — slats open
 FULLY_CLOSED_POSITION = pynormanshutters.FULLY_CLOSED_POSITION  # 100 — slats closed
@@ -114,3 +114,84 @@ async def test_close_cover(fake_coordinator):
     await cover.async_close_cover()
     fake_coordinator.client.close_window.assert_called_once_with(42)
     fake_coordinator.async_request_aggressive_refresh.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# NormanHubCover
+# ---------------------------------------------------------------------------
+
+WINDOW_A = {**BASE_WINDOW, "Id": 10, "Name": "A"}
+WINDOW_B = {**BASE_WINDOW, "Id": 20, "Name": "B"}
+
+
+def make_hub_cover(coordinator, windows: dict):
+    coordinator.data = windows
+    return NormanHubCover(coordinator)
+
+
+def test_hub_cover_unique_id(fake_coordinator):
+    cover = make_hub_cover(fake_coordinator, {})
+    assert cover.unique_id == "hub_AABBCCDDEEFF_cover"
+
+
+def test_hub_cover_name(fake_coordinator):
+    cover = make_hub_cover(fake_coordinator, {})
+    assert cover._attr_name == "All Shutters"
+
+
+def test_hub_cover_is_closed_all_closed(fake_coordinator):
+    windows = {
+        "10": {**WINDOW_A, "position": FULLY_CLOSED_POSITION},
+        "20": {**WINDOW_B, "position": FULLY_CLOSED_POSITION},
+    }
+    cover = make_hub_cover(fake_coordinator, windows)
+    assert cover.is_closed is True
+
+
+def test_hub_cover_is_closed_some_open(fake_coordinator):
+    windows = {
+        "10": {**WINDOW_A, "position": FULLY_CLOSED_POSITION},
+        "20": {**WINDOW_B, "position": FULLY_OPEN_POSITION},
+    }
+    cover = make_hub_cover(fake_coordinator, windows)
+    assert cover.is_closed is False
+
+
+def test_hub_cover_is_closed_none_when_empty(fake_coordinator):
+    cover = make_hub_cover(fake_coordinator, {})
+    assert cover.is_closed is None
+
+
+def test_hub_cover_is_closed_none_when_position_missing(fake_coordinator):
+    windows = {"10": {k: v for k, v in WINDOW_A.items() if k != "position"}}
+    cover = make_hub_cover(fake_coordinator, windows)
+    assert cover.is_closed is None
+
+
+async def test_hub_cover_open_calls_full_open(fake_coordinator):
+    windows = {"10": WINDOW_A, "20": WINDOW_B}
+    cover = make_hub_cover(fake_coordinator, windows)
+    await cover.async_open_cover()
+    fake_coordinator.client.full_open.assert_called_once_with()
+    fake_coordinator.async_request_aggressive_refresh.assert_called_once()
+
+
+async def test_hub_cover_close_calls_full_close(fake_coordinator):
+    windows = {"10": WINDOW_A, "20": WINDOW_B}
+    cover = make_hub_cover(fake_coordinator, windows)
+    await cover.async_close_cover()
+    fake_coordinator.client.full_close.assert_called_once_with()
+    fake_coordinator.async_request_aggressive_refresh.assert_called_once()
+
+
+def test_hub_cover_device_info_has_mac(fake_coordinator):
+    cover = make_hub_cover(fake_coordinator, {})
+    info = cover.device_info
+    connections = info["connections"]
+    assert ("mac", "aa:bb:cc:dd:ee:ff") in connections
+
+
+def test_cover_device_info_has_via_device(fake_coordinator):
+    cover = make_cover(fake_coordinator, BASE_WINDOW)
+    info = cover.device_info
+    assert info["via_device"] == ("norman_shutters", "hub_AABBCCDDEEFF")

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,5 +1,6 @@
 from custom_components.norman_shutters.sensor import (
     NormanBatterySensor,
+    NormanConnectedWindowsSensor,
     NormanRssiSensor,
     NormanTemperatureSensor,
 )
@@ -158,3 +159,46 @@ def test_rssi_native_value_none_when_missing(fake_coordinator):
 def test_rssi_unique_id(fake_coordinator):
     sensor = make_rssi_sensor(fake_coordinator, BASE_WINDOW)
     assert sensor._attr_unique_id == "42_rssi"
+
+
+# ---------------------------------------------------------------------------
+# NormanConnectedWindowsSensor
+# ---------------------------------------------------------------------------
+
+
+def test_connected_windows_name(fake_coordinator):
+    fake_coordinator.data = {}
+    sensor = NormanConnectedWindowsSensor(fake_coordinator)
+    assert sensor._attr_name == "Connected Shutters"
+
+
+def test_connected_windows_unique_id(fake_coordinator):
+    fake_coordinator.data = {}
+    sensor = NormanConnectedWindowsSensor(fake_coordinator)
+    assert sensor.unique_id == "hub_AABBCCDDEEFF_connected_shutters"
+
+
+def test_connected_windows_value(fake_coordinator):
+    fake_coordinator.data = {"42": BASE_WINDOW, "99": BASE_WINDOW}
+    sensor = NormanConnectedWindowsSensor(fake_coordinator)
+    assert sensor.native_value == 2
+
+
+def test_connected_windows_value_empty(fake_coordinator):
+    fake_coordinator.data = {}
+    sensor = NormanConnectedWindowsSensor(fake_coordinator)
+    assert sensor.native_value == 0
+
+
+def test_connected_windows_device_info_has_mac(fake_coordinator):
+    fake_coordinator.data = {}
+    sensor = NormanConnectedWindowsSensor(fake_coordinator)
+    info = sensor.device_info
+    connections = info["connections"]
+    assert ("mac", "aa:bb:cc:dd:ee:ff") in connections
+
+
+def test_window_sensor_device_info_has_via_device(fake_coordinator):
+    sensor = make_sensor(fake_coordinator, BASE_WINDOW)
+    info = sensor.device_info
+    assert info["via_device"] == ("norman_shutters", "hub_AABBCCDDEEFF")


### PR DESCRIPTION
Closes #13

Adds a Norman Hub device entry grouping all shutter entities under a single hub device, identified by MAC address for deduplication with e.g. UniFi.

## Changes

### Norman Hub device
- **"All Shutters" cover** — uses `client.full_open()` / `client.full_close()` for atomic hub-level open/close commands
- **"Connected Shutters" sensor** — shows the count of registered shutters
- Per-shutter entities linked to the hub via `via_device`
- MAC address reconstructed from the Norman OUI + zeroconf service name suffix (e.g. `NORMANHUB_9DDAA3` → `805E4F9DDAA3`)

### Zombie coordinator fix
Passes `config_entry` to `DataUpdateCoordinator.__init__` so HA automatically shuts down the coordinator on integration unload. Without this, old coordinators kept polling after a reload, invalidating the new coordinator's hub session and causing all entities to go unavailable.

Generated with [Claude Code](https://claude.ai/code)