### PR TITLE
fix: remove double-prefixed entity names on per-window cover and sensors

### DIFF
--- a/custom_components/norman_shutters/cover.py
+++ b/custom_components/norman_shutters/cover.py
@@ -36,14 +36,11 @@ class NormanCover(NormanEntity, CoverEntity):
 
     _attr_device_class = CoverDeviceClass.SHUTTER
     _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+    _attr_name = None
 
     def __init__(self, coordinator: NormanCoordinator, window_id: str) -> None:
         super().__init__(coordinator, window_id)
         self._attr_unique_id = window_id
-
-    @property
-    def name(self) -> str:
-        return f"{self._window.get('Name', self._window_id)} Cover"
 
     @property
     def is_closed(self) -> bool | None:

--- a/custom_components/norman_shutters/sensor.py
+++ b/custom_components/norman_shutters/sensor.py
@@ -58,14 +58,11 @@ class NormanBatterySensor(NormanEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_name = "Battery"
 
     def __init__(self, coordinator: NormanCoordinator, window_id: str) -> None:
         super().__init__(coordinator, window_id)
         self._attr_unique_id = f"{window_id}_battery"
-
-    @property
-    def name(self) -> str:
-        return f"{self._window.get('Name', self._window_id)} Battery"
 
     @property
     def native_value(self) -> int | None:
@@ -79,14 +76,11 @@ class NormanTemperatureSensor(NormanEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_name = "Temperature"
 
     def __init__(self, coordinator: NormanCoordinator, window_id: str) -> None:
         super().__init__(coordinator, window_id)
         self._attr_unique_id = f"{window_id}_temperature"
-
-    @property
-    def name(self) -> str:
-        return f"{self._window.get('Name', self._window_id)} Temperature"
 
     @property
     def native_value(self) -> int | None:
@@ -100,14 +94,11 @@ class NormanRssiSensor(NormanEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
     _attr_native_unit_of_measurement = "dBm"
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_name = "Signal Strength"
 
     def __init__(self, coordinator: NormanCoordinator, window_id: str) -> None:
         super().__init__(coordinator, window_id)
         self._attr_unique_id = f"{window_id}_rssi"
-
-    @property
-    def name(self) -> str:
-        return f"{self._window.get('Name', self._window_id)} Signal Strength"
 
     @property
     def native_value(self) -> int | None:

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -27,15 +27,21 @@ def make_cover(coordinator, window_data):
 # ---------------------------------------------------------------------------
 
 
-def test_name_from_Name_key(fake_coordinator):
+def test_name_is_none_so_device_name_is_used(fake_coordinator):
     cover = make_cover(fake_coordinator, {**BASE_WINDOW, "Name": "Lounge"})
-    assert cover.name == "Lounge Cover"
+    assert cover._attr_name is None
+    assert cover._attr_has_entity_name is True
 
 
-def test_name_falls_back_to_window_id(fake_coordinator):
+def test_device_info_uses_window_name(fake_coordinator):
+    cover = make_cover(fake_coordinator, {**BASE_WINDOW, "Name": "Lounge"})
+    assert cover.device_info["name"] == "Lounge"
+
+
+def test_device_info_falls_back_to_window_id(fake_coordinator):
     data = {k: v for k, v in BASE_WINDOW.items() if k != "Name"}
     cover = make_cover(fake_coordinator, data)
-    assert cover.name == "42 Cover"
+    assert cover.device_info["name"] == "42"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -35,15 +35,9 @@ def make_rssi_sensor(coordinator, window_data):
 # ---------------------------------------------------------------------------
 
 
-def test_name_with_Name_key(fake_coordinator):
-    sensor = make_sensor(fake_coordinator, {**BASE_WINDOW, "Name": "Bedroom"})
-    assert sensor.name == "Bedroom Battery"
-
-
-def test_name_falls_back_to_window_id(fake_coordinator):
-    data = {k: v for k, v in BASE_WINDOW.items() if k != "Name"}
-    sensor = make_sensor(fake_coordinator, data)
-    assert sensor.name == "42 Battery"
+def test_battery_subname(fake_coordinator):
+    sensor = make_sensor(fake_coordinator, BASE_WINDOW)
+    assert sensor._attr_name == "Battery"
 
 
 # ---------------------------------------------------------------------------
@@ -82,15 +76,9 @@ def test_unique_id(fake_coordinator):
 # ---------------------------------------------------------------------------
 
 
-def test_temperature_name_with_Name_key(fake_coordinator):
-    sensor = make_temperature_sensor(fake_coordinator, {**BASE_WINDOW, "Name": "Bedroom"})
-    assert sensor.name == "Bedroom Temperature"
-
-
-def test_temperature_name_falls_back_to_window_id(fake_coordinator):
-    data = {k: v for k, v in BASE_WINDOW.items() if k != "Name"}
-    sensor = make_temperature_sensor(fake_coordinator, data)
-    assert sensor.name == "42 Temperature"
+def test_temperature_subname(fake_coordinator):
+    sensor = make_temperature_sensor(fake_coordinator, BASE_WINDOW)
+    assert sensor._attr_name == "Temperature"
 
 
 # ---------------------------------------------------------------------------
@@ -124,15 +112,9 @@ def test_temperature_unique_id(fake_coordinator):
 # ---------------------------------------------------------------------------
 
 
-def test_rssi_name_with_Name_key(fake_coordinator):
-    sensor = make_rssi_sensor(fake_coordinator, {**BASE_WINDOW, "Name": "Bedroom"})
-    assert sensor.name == "Bedroom Signal Strength"
-
-
-def test_rssi_name_falls_back_to_window_id(fake_coordinator):
-    data = {k: v for k, v in BASE_WINDOW.items() if k != "Name"}
-    sensor = make_rssi_sensor(fake_coordinator, data)
-    assert sensor.name == "42 Signal Strength"
+def test_rssi_subname(fake_coordinator):
+    sensor = make_rssi_sensor(fake_coordinator, BASE_WINDOW)
+    assert sensor._attr_name == "Signal Strength"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Per-window entities (`NormanCover`, `NormanBatterySensor`, `NormanTemperatureSensor`, `NormanRssiSensor`) inherited `_attr_has_entity_name = True` from `NormanEntity` but also overrode `name()` to return the full `"{device name} {role}"` string
- HA was prepending the device name a second time, producing entity_ids like `cover.left_window_1_left_window_1_cover`
- Fixed by setting `_attr_name = None` on `NormanCover` (primary entity of its device) and explicit subnames on the three sensors — matching the pattern already used correctly by `NormanHubCover` and `NormanConnectedWindowsSensor`

**Before:** `cover.left_window_1_left_window_1_cover`
**After:** `cover.left_window_1`

> Note: existing HA instances will retain old entity_id slugs (entity registry keys by unique_id). Delete and rediscover affected entities to get clean IDs.

## Test plan

- [x] `make all` passes (72 tests, lint, format)
- [ ] Verify new/recreated cover entities have entity_ids of form `cover.<window_slug>` with no repeated segment
- [ ] Verify sensor entity_ids: `sensor.<window_slug>_battery`, `sensor.<window_slug>_temperature`, `sensor.<window_slug>_signal_strength`
- [ ] Verify hub entities (`cover.norman_hub_all_shutters`, `sensor.norman_hub_connected_shutters`) are unchanged