### PR TITLE
fix: remove double-prefixed entity names on per-window cover and sensors (#15)

### DIFF
--- a/custom_components/norman_shutters/cover.py
+++ b/custom_components/norman_shutters/cover.py
@@ -36,14 +36,11 @@ class NormanCover(NormanEntity, CoverEntity):
 
     _attr_device_class = CoverDeviceClass.SHUTTER
     _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+    _attr_name = None
 
     def __init__(self, coordinator: NormanCoordinator, window_id: str) -> None:
         super().__init__(coordinator, window_id)
         self._attr_unique_id = window_id
-
-    @property
-    def name(self) -> str:
-        return f"{self._window.get('Name', self._window_id)} Cover"
 
     @property
     def is_closed(self) -> bool | None:
@@ -76,10 +73,10 @@ class NormanHubCover(NormanHubEntity, CoverEntity):
 
     _attr_device_class = CoverDeviceClass.SHUTTER
     _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+    _attr_name = "All Shutters"
 
     def __init__(self, coordinator: NormanCoordinator) -> None:
         super().__init__(coordinator)
-        self._attr_name = "All Shutters"
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/norman_shutters/sensor.py
+++ b/custom_components/norman_shutters/sensor.py
@@ -38,10 +38,10 @@ class NormanConnectedWindowsSensor(NormanHubEntity, SensorEntity):
     """Sensor reporting how many shutters are connected to the Norman Hub."""
 
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_name = "Connected Shutters"
 
     def __init__(self, coordinator: NormanCoordinator) -> None:
         super().__init__(coordinator)
-        self._attr_name = "Connected Shutters"
 
     @property
     def unique_id(self) -> str:
@@ -58,14 +58,11 @@ class NormanBatterySensor(NormanEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_name = "Battery"
 
     def __init__(self, coordinator: NormanCoordinator, window_id: str) -> None:
         super().__init__(coordinator, window_id)
         self._attr_unique_id = f"{window_id}_battery"
-
-    @property
-    def name(self) -> str:
-        return f"{self._window.get('Name', self._window_id)} Battery"
 
     @property
     def native_value(self) -> int | None:
@@ -79,14 +76,11 @@ class NormanTemperatureSensor(NormanEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_name = "Temperature"
 
     def __init__(self, coordinator: NormanCoordinator, window_id: str) -> None:
         super().__init__(coordinator, window_id)
         self._attr_unique_id = f"{window_id}_temperature"
-
-    @property
-    def name(self) -> str:
-        return f"{self._window.get('Name', self._window_id)} Temperature"
 
     @property
     def native_value(self) -> int | None:
@@ -100,14 +94,11 @@ class NormanRssiSensor(NormanEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
     _attr_native_unit_of_measurement = "dBm"
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_name = "Signal Strength"
 
     def __init__(self, coordinator: NormanCoordinator, window_id: str) -> None:
         super().__init__(coordinator, window_id)
         self._attr_unique_id = f"{window_id}_rssi"
-
-    @property
-    def name(self) -> str:
-        return f"{self._window.get('Name', self._window_id)} Signal Strength"
 
     @property
     def native_value(self) -> int | None:

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -27,15 +27,27 @@ def make_cover(coordinator, window_data):
 # ---------------------------------------------------------------------------
 
 
-def test_name_from_Name_key(fake_coordinator):
-    cover = make_cover(fake_coordinator, {**BASE_WINDOW, "Name": "Lounge"})
-    assert cover.name == "Lounge Cover"
+def test_name_is_window_name(fake_coordinator):
+    cover = make_cover(fake_coordinator, BASE_WINDOW)
+    assert cover._attr_name == "Living Room"
+    assert cover._attr_has_entity_name is False
 
 
 def test_name_falls_back_to_window_id(fake_coordinator):
     data = {k: v for k, v in BASE_WINDOW.items() if k != "Name"}
     cover = make_cover(fake_coordinator, data)
-    assert cover.name == "42 Cover"
+    assert cover._attr_name == "42"
+
+
+def test_device_info_uses_window_name(fake_coordinator):
+    cover = make_cover(fake_coordinator, {**BASE_WINDOW, "Name": "Lounge"})
+    assert cover.device_info["name"] == "Lounge"
+
+
+def test_device_info_falls_back_to_window_id(fake_coordinator):
+    data = {k: v for k, v in BASE_WINDOW.items() if k != "Name"}
+    cover = make_cover(fake_coordinator, data)
+    assert cover.device_info["name"] == "42"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -27,16 +27,10 @@ def make_cover(coordinator, window_data):
 # ---------------------------------------------------------------------------
 
 
-def test_name_is_window_name(fake_coordinator):
+def test_name_is_primary_entity(fake_coordinator):
     cover = make_cover(fake_coordinator, BASE_WINDOW)
-    assert cover._attr_name == "Living Room"
-    assert cover._attr_has_entity_name is False
-
-
-def test_name_falls_back_to_window_id(fake_coordinator):
-    data = {k: v for k, v in BASE_WINDOW.items() if k != "Name"}
-    cover = make_cover(fake_coordinator, data)
-    assert cover._attr_name == "42"
+    assert cover._attr_name is None
+    assert cover._attr_has_entity_name is True
 
 
 def test_device_info_uses_window_name(fake_coordinator):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -35,15 +35,10 @@ def make_rssi_sensor(coordinator, window_data):
 # ---------------------------------------------------------------------------
 
 
-def test_name_with_Name_key(fake_coordinator):
-    sensor = make_sensor(fake_coordinator, {**BASE_WINDOW, "Name": "Bedroom"})
-    assert sensor.name == "Bedroom Battery"
-
-
-def test_name_falls_back_to_window_id(fake_coordinator):
-    data = {k: v for k, v in BASE_WINDOW.items() if k != "Name"}
-    sensor = make_sensor(fake_coordinator, data)
-    assert sensor.name == "42 Battery"
+def test_battery_name(fake_coordinator):
+    sensor = make_sensor(fake_coordinator, BASE_WINDOW)
+    assert sensor._attr_name == "Bedroom Battery"
+    assert sensor._attr_has_entity_name is False
 
 
 # ---------------------------------------------------------------------------
@@ -82,15 +77,10 @@ def test_unique_id(fake_coordinator):
 # ---------------------------------------------------------------------------
 
 
-def test_temperature_name_with_Name_key(fake_coordinator):
-    sensor = make_temperature_sensor(fake_coordinator, {**BASE_WINDOW, "Name": "Bedroom"})
-    assert sensor.name == "Bedroom Temperature"
-
-
-def test_temperature_name_falls_back_to_window_id(fake_coordinator):
-    data = {k: v for k, v in BASE_WINDOW.items() if k != "Name"}
-    sensor = make_temperature_sensor(fake_coordinator, data)
-    assert sensor.name == "42 Temperature"
+def test_temperature_name(fake_coordinator):
+    sensor = make_temperature_sensor(fake_coordinator, BASE_WINDOW)
+    assert sensor._attr_name == "Bedroom Temperature"
+    assert sensor._attr_has_entity_name is False
 
 
 # ---------------------------------------------------------------------------
@@ -119,20 +109,20 @@ def test_temperature_unique_id(fake_coordinator):
     assert sensor._attr_unique_id == "42_temperature"
 
 
+def test_temperature_entity_id(fake_coordinator):
+    sensor = make_temperature_sensor(fake_coordinator, BASE_WINDOW)
+    assert sensor.entity_id == "sensor.bedroom_temperature"
+
+
 # ---------------------------------------------------------------------------
 # NormanRssiSensor — name
 # ---------------------------------------------------------------------------
 
 
-def test_rssi_name_with_Name_key(fake_coordinator):
-    sensor = make_rssi_sensor(fake_coordinator, {**BASE_WINDOW, "Name": "Bedroom"})
-    assert sensor.name == "Bedroom Signal Strength"
-
-
-def test_rssi_name_falls_back_to_window_id(fake_coordinator):
-    data = {k: v for k, v in BASE_WINDOW.items() if k != "Name"}
-    sensor = make_rssi_sensor(fake_coordinator, data)
-    assert sensor.name == "42 Signal Strength"
+def test_rssi_subname(fake_coordinator):
+    sensor = make_rssi_sensor(fake_coordinator, BASE_WINDOW)
+    assert sensor._attr_name == "Signal Strength"
+    assert sensor._attr_has_entity_name is True
 
 
 # ---------------------------------------------------------------------------
@@ -159,6 +149,11 @@ def test_rssi_native_value_none_when_missing(fake_coordinator):
 def test_rssi_unique_id(fake_coordinator):
     sensor = make_rssi_sensor(fake_coordinator, BASE_WINDOW)
     assert sensor._attr_unique_id == "42_rssi"
+
+
+def test_rssi_entity_id(fake_coordinator):
+    sensor = make_rssi_sensor(fake_coordinator, BASE_WINDOW)
+    assert sensor.entity_id == "sensor.bedroom_signal_strength"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -37,8 +37,8 @@ def make_rssi_sensor(coordinator, window_data):
 
 def test_battery_name(fake_coordinator):
     sensor = make_sensor(fake_coordinator, BASE_WINDOW)
-    assert sensor._attr_name == "Bedroom Battery"
-    assert sensor._attr_has_entity_name is False
+    assert sensor._attr_name == "Battery"
+    assert sensor._attr_has_entity_name is True
 
 
 # ---------------------------------------------------------------------------
@@ -79,8 +79,8 @@ def test_unique_id(fake_coordinator):
 
 def test_temperature_name(fake_coordinator):
     sensor = make_temperature_sensor(fake_coordinator, BASE_WINDOW)
-    assert sensor._attr_name == "Bedroom Temperature"
-    assert sensor._attr_has_entity_name is False
+    assert sensor._attr_name == "Temperature"
+    assert sensor._attr_has_entity_name is True
 
 
 # ---------------------------------------------------------------------------
@@ -107,11 +107,6 @@ def test_temperature_native_value_none_when_missing(fake_coordinator):
 def test_temperature_unique_id(fake_coordinator):
     sensor = make_temperature_sensor(fake_coordinator, BASE_WINDOW)
     assert sensor._attr_unique_id == "42_temperature"
-
-
-def test_temperature_entity_id(fake_coordinator):
-    sensor = make_temperature_sensor(fake_coordinator, BASE_WINDOW)
-    assert sensor.entity_id == "sensor.bedroom_temperature"
 
 
 # ---------------------------------------------------------------------------
@@ -149,11 +144,6 @@ def test_rssi_native_value_none_when_missing(fake_coordinator):
 def test_rssi_unique_id(fake_coordinator):
     sensor = make_rssi_sensor(fake_coordinator, BASE_WINDOW)
     assert sensor._attr_unique_id == "42_rssi"
-
-
-def test_rssi_entity_id(fake_coordinator):
-    sensor = make_rssi_sensor(fake_coordinator, BASE_WINDOW)
-    assert sensor.entity_id == "sensor.bedroom_signal_strength"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Per-window entities inherited _attr_has_entity_name = True from NormanEntity but also overrode name() to return the full "{device name} {role}" string. HA was prepending the device name a second time, producing entity_ids like cover.left_window_1_left_window_1.

Set _attr_name = None on NormanCover (making it the primary entity for its device) and _attr_name = "Battery" / "Temperature" / "Signal Strength" on the three per-window sensors, matching the pattern already used by the hub-level entities.