### PR TITLE
fix: use correct pynormanshutters method names fullopen/fullclose

### DIFF
--- a/custom_components/norman_shutters/cover.py
+++ b/custom_components/norman_shutters/cover.py
@@ -93,10 +93,10 @@ class NormanHubCover(NormanHubEntity, CoverEntity):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         _LOGGER.debug("open_cover called for all windows")
-        await self.hass.async_add_executor_job(self.coordinator.client.full_open)
+        await self.hass.async_add_executor_job(self.coordinator.client.fullopen)
         await self.coordinator.async_request_aggressive_refresh()
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         _LOGGER.debug("close_cover called for all windows")
-        await self.hass.async_add_executor_job(self.coordinator.client.full_close)
+        await self.hass.async_add_executor_job(self.coordinator.client.fullclose)
         await self.coordinator.async_request_aggressive_refresh()

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -174,19 +174,19 @@ def test_hub_cover_is_closed_none_when_position_missing(fake_coordinator):
     assert cover.is_closed is None
 
 
-async def test_hub_cover_open_calls_full_open(fake_coordinator):
+async def test_hub_cover_open_calls_fullopen(fake_coordinator):
     windows = {"10": WINDOW_A, "20": WINDOW_B}
     cover = make_hub_cover(fake_coordinator, windows)
     await cover.async_open_cover()
-    fake_coordinator.client.full_open.assert_called_once_with()
+    fake_coordinator.client.fullopen.assert_called_once_with()
     fake_coordinator.async_request_aggressive_refresh.assert_called_once()
 
 
-async def test_hub_cover_close_calls_full_close(fake_coordinator):
+async def test_hub_cover_close_calls_fullclose(fake_coordinator):
     windows = {"10": WINDOW_A, "20": WINDOW_B}
     cover = make_hub_cover(fake_coordinator, windows)
     await cover.async_close_cover()
-    fake_coordinator.client.full_close.assert_called_once_with()
+    fake_coordinator.client.fullclose.assert_called_once_with()
     fake_coordinator.async_request_aggressive_refresh.assert_called_once()
 
 


### PR DESCRIPTION
The `Client` class exposes `fullopen()` and `fullclose()` (no underscore), not `full_open()` / `full_close()`. Fixes the AttributeError when closing all shutters via the hub cover entity.

Closes #19

Generated with [Claude Code](https://claude.ai/code)